### PR TITLE
Remove lager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,9 @@ pbx: app
 		-args_file samples/nksip_pbx/priv/vm.args
 
 build_tests:
-	erlc -pa ebin -pa deps/lager/ebin -pa deps/nklib/ebin -pa deps/nkpacket/ebin \
+	erlc -pa ebin -pa deps/nklib/ebin -pa deps/nkpacket/ebin \
 	-o ebin -I include \
-	+export_all +debug_info +"{parse_transform, lager_transform}" \
+	+export_all +debug_info \
 	test/*.erl
 
 

--- a/doc/guide/start_nksip.md
+++ b/doc/guide/start_nksip.md
@@ -14,7 +14,7 @@ If you want to embed NkSIP in your own Erlang application, and you are using _re
 ]}.
 ```
  
-Then you will have to setup in your erlang environment any [configuration parameter](../reference/configuration.md) you want to change from NkSIP's defaults (usually in your `app.config` file), for `nksip` but also some dependant applications like `nkservice`, `nkpacket` or `lager`. You can then start NkSIP starting all dependencies (see [nksip.app.src](../../src/nksip.app.src)) and finally start `nksip` Erlang application.
+Then you will have to setup in your erlang environment any [configuration parameter](../reference/configuration.md) you want to change from NkSIP's defaults (usually in your `app.config` file), for `nksip` but also some dependant applications like `nkservice` or `nkpacket`. You can then start NkSIP starting all dependencies (see [nksip.app.src](../../src/nksip.app.src)) and finally start `nksip` Erlang application.
 
 
 

--- a/doc/reference/callback_functions.md
+++ b/doc/reference/callback_functions.md
@@ -507,7 +507,7 @@ handle_call(Msg::term(), From::from(), State::map()) ->
       when State :: term(), Timeout :: infinity | non_neg_integer(), Reason :: term().
 
 handle_call(Msg, _From, State) ->
-    lager:warning("Unexpected handle_call in ~p: ~p", [Msg, ?MODULE]),
+    logger:warning("Unexpected handle_call in ~p: ~p", [Msg, ?MODULE]),
     {noreply, State}.
 ```
 
@@ -522,7 +522,7 @@ handle_cast(Msg::term(), State::map()) ->
       when State :: term(), Timeout :: infinity | non_neg_integer(), Reason :: term().
 
 handle_cast(Msg, State) ->
-    lager:warning("Unexpected handle_cast in ~p: ~p", [Msg, ?MODULE]),
+    logger:warning("Unexpected handle_cast in ~p: ~p", [Msg, ?MODULE]),
     {noreply, State}.
 ```
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -36,8 +36,7 @@ tls_depth|`integer()`|0|TLS check depth
 
 Name|Type|Default|Comments
 ---|---|---|---
-log_path|`string`|"./log"|Directory for NkSERVICE files (you must configure lager also)
-log_level|`debug`&#124;`info`&#124;`notice`&#124;`warning`&#124;`error`|`notice`|Current global log level
+log_path|`string`|"./log"|Directory for NkSERVICE files (used for cache)
 
 
 ### nksip
@@ -67,10 +66,6 @@ sip_max_calls|`integer()`|100000|Maximum number of simultaneous calls (for each 
 sip_local_host|auto&#124;`string()`&#124;`binary()`&#124;|auto|Default host or IP to use in headers like _Via_, _Contact_ and _Record-Route_. If set to `auto` NkSIP will use the IP of the transport selected in every case. If that transport is listening on all addresses NkSIP will try to find the best IP using the first valid IP among the network interfaces `ethX` and `enX`, or localhost if none is found
 sip_local_host6|auto&#124;`string()`&#124;`binary()`|auto|Default host or IP to use in headers like _Via_, _Contact_ and _Record-Route_ for IPv6 transports. See `local_host` option
 sip_udp_max_size|`integer()`|65507|Maximum UDP packet size. Bigger packets will be sent using TCP
-
-### lager
-
-See specific lager configuration
 
 
 ## Service Configuration

--- a/doc/reference/log.md
+++ b/doc/reference/log.md
@@ -1,6 +1,6 @@
 # Logging Options
 
-NkSIP uses [Lager](https://github.com/basho/lager) for logging, supporting multiple log levels, log rotation, etc. The following `Lager` levels are used:
+NkSIP uses [logger](https://www.erlang.org/doc/apps/kernel/logger.html) for logging, supporting multiple log levels, log rotation, etc. The following `logger` levels are used:
 
 Level|Typical use
 ---|---
@@ -13,10 +13,6 @@ Level|Typical use
 `alert`|Not used currently
 `emergency`|Not used currently
 
-You can configure Lager using its erlang environment variables, or using an erlang start up configuration file (usually called `app.config`). See the `samples` directory for an example of use.
-
-Lager supports several backends, typically console and disk. You can change the current _log level_ with `lager:set_loglevel/2,3` (for example `lager:set_loglevel(lager_console_backend, debug)` and `lager:set_loglevel(lager_file_backend, "console.log", debug)`).
-
-In order for a Service to change its log level, not only the global log level must be changed, but also the [application configuration](configuration.md), using the `log_level` option. Service config options can be changed on the fly.
+You can configure logger using its erlang environment variables, or using an erlang start up configuration file (usually called `app.config`). See the `samples` directory for an example of use.
 
 To get SIP message tracing, activate the [nksip_trace](../plugins/trace.md) plugin.

--- a/include/nksip.hrl
+++ b/include/nksip.hrl
@@ -32,9 +32,9 @@
     DO_LOG(Level, Srv, CallId, Text, Opts),
     case CallId of
         <<>> ->
-            lager:Level([{app, Srv}], "~p "++Text, [Srv|Opts]);
-        _ -> 
-            lager:Level([{app, Srv}, {call_id, CallId}], "~p (~s) "++Text, [Srv, CallId|Opts])
+            logger:Level("~p "++Text, [Srv|Opts]);
+        _ ->
+            logger:Level("~p (~s) "++Text, [Srv, CallId|Opts])
     end).
 
 -define(DO_DEBUG(SrvId, CallId, Level, Text, List),
@@ -264,7 +264,7 @@
 % -endif.
 
 % -ifndef(I).
-% -define(I(S,P), lager:info(S++"\n", P)).
+% -define(I(S,P), logger:info(S++"\n", P)).
 % -define(I(S), ?I(S, [])).
 % -endif.
 

--- a/priv/app.config
+++ b/priv/app.config
@@ -4,23 +4,6 @@
 
     ]},
 
-    {lager, [
-        {handlers, [
-            {lager_console_backend, info},
-            {lager_file_backend, [{file, "log/error.log"}, {level, error}]},
-            {lager_file_backend, [{file, "log/console.log"}, {level, info}]}
-        ]},
-        {error_logger_redirect, false},
-        {crash_log, "log/crash.log"},
-        {colored, true},
-        {colors, [
-            {debug,     "\e[0;38m" },
-            {info,      "\e[0;32m" },
-            {notice,    "\e[1;36m" },
-            {warning,   "\e[1;33m" },
-            {error,     "\e[1;31m" }
-        ]}
-    ]},
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/priv/vm.args
+++ b/priv/vm.args
@@ -3,7 +3,6 @@
 -pa deps/goldrush/ebin 
 -pa deps/gun/ebin 
 -pa deps/jsx/ebin
--pa deps/lager/ebin 
 -pa deps/nkdocker/ebin
 -pa deps/nklib/ebin
 -pa deps/nkpacket/ebin

--- a/rebar.config
+++ b/rebar.config
@@ -18,5 +18,5 @@
 {cover_export_enabled, true}.
 
 {deps, [
-    {nkservice, ".*", {git, "https://github.com/esl/nkservice", {branch, "remove-lager"}}}
+    {nkservice, ".*", {git, "https://github.com/esl/nkservice", {branch, "mongooseim"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,14 +11,12 @@
 
 {erl_opts, [
     % native,
-    debug_info, 
-    fail_on_warning, 
-    {parse_transform, lager_transform}
+    debug_info
 ]}.
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.
 
 {deps, [
-    {nkservice, ".*", {git, "https://github.com/Nekso/nkservice", {tag, "v0.2.0"}}}
+    {nkservice, ".*", {git, "https://github.com/esl/nkservice", {branch, "remove-lager"}}}
 ]}.

--- a/samples/nksip_loadtest/priv/app.config
+++ b/samples/nksip_loadtest/priv/app.config
@@ -5,30 +5,6 @@
     {nksip_loadtest, [
     ]},
 
-    {lager, [
-        {handlers, [
-            {lager_console_backend, notice},
-            {lager_file_backend, [
-                {file, "samples/nksip_loadtest/log/error.log"}, 
-                {level, error}
-            ]},
-            {lager_file_backend, [
-                {file, "samples/nksip_loadtest/log/console.log"}, 
-                {level, info}
-            ]}
-        ]},
-        {error_logger_redirect, false},
-        {colors, [
-            {debug,     "\e[0;38m" },
-            {info,      "\e[0;32m" },
-            {notice,    "\e[1;36m" },
-            {warning,   "\e[1;33m" },
-            {error,     "\e[1;31m" }
-        ]},
-        {crash_log, "samples/nksip_loadtest/log/crash.log"},
-        {colored, true}
-    ]},
-
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/samples/nksip_loadtest/priv/vm.args
+++ b/samples/nksip_loadtest/priv/vm.args
@@ -3,7 +3,6 @@
 -pa deps/goldrush/ebin 
 -pa deps/gun/ebin 
 -pa deps/jsx/ebin
--pa deps/lager/ebin 
 -pa deps/nkdocker/ebin
 -pa deps/nklib/ebin
 -pa deps/nkpacket/ebin

--- a/samples/nksip_pbx/priv/app.config
+++ b/samples/nksip_pbx/priv/app.config
@@ -5,29 +5,6 @@
     {nksip_pbx, [
     ]},
 
-    {lager, [
-        {handlers, [
-            {lager_console_backend, notice},
-            {lager_file_backend, [
-                {file, "samples/nksip_pbx/log/error.log"}, 
-                {level, error}
-            ]},
-            {lager_file_backend, [
-                {file, "samples/nksip_pbx/log/console.log"}, 
-                {level, info}
-            ]}
-        ]},
-        {crash_log, "samples/nksip_pbx/log/crash.log"},
-        {colored, true},
-        {colors, [
-            {debug,     "\e[0;38m" },
-            {info,      "\e[0;32m" },
-            {notice,    "\e[1;36m" },
-            {warning,   "\e[1;33m" },
-            {error,     "\e[1;31m" }
-        ]}
-    ]},
-
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/samples/nksip_pbx/priv/vm.args
+++ b/samples/nksip_pbx/priv/vm.args
@@ -3,7 +3,6 @@
 -pa deps/goldrush/ebin 
 -pa deps/gun/ebin 
 -pa deps/jsx/ebin
--pa deps/lager/ebin 
 -pa deps/nkdocker/ebin
 -pa deps/nklib/ebin
 -pa deps/nkpacket/ebin

--- a/samples/nksip_pbx/src/nksip_pbx_callbacks.erl
+++ b/samples/nksip_pbx/src/nksip_pbx_callbacks.erl
@@ -80,7 +80,7 @@ sip_get_user_pass(_User, _Realm, _Req, _Call) ->
 
 sip_authorize(Auth, Req, _Call) ->
     {ok, Method} = nksip_request:method(Req),
-    lager:info("Request ~p auth data: ~p", [Method, Auth]),
+    logger:info("Request ~p auth data: ~p", [Method, Auth]),
     case lists:member(dialog, Auth) orelse lists:member(register, Auth) of
         true -> 
             ok;
@@ -163,27 +163,27 @@ sip_route(_Scheme, _User, _Domain, Req, _Call) ->
 
 sip_dialog_update(Status, Dialog, _Call) ->
     {ok, DialogId} = nksip_dialog:get_handle(Dialog),
-    lager:notice("PBX Dialog ~s Update: ~p", [DialogId, Status]),
+    logger:notice("PBX Dialog ~s Update: ~p", [DialogId, Status]),
     ok.
 
 
 sip_session_update({start, LocalSDP, RemoteSDP}, Dialog, _Call) ->
     {ok, DialogId} = nksip_dialog:get_handle(Dialog),
-    lager:notice("PBX Session ~s Start", [DialogId]),
-    lager:notice("Local SDP: ~s", [nksip_sdp:unparse(LocalSDP)]),
-    lager:notice("Remote SDP: ~s", [nksip_sdp:unparse(RemoteSDP)]),
+    logger:notice("PBX Session ~s Start", [DialogId]),
+    logger:notice("Local SDP: ~s", [nksip_sdp:unparse(LocalSDP)]),
+    logger:notice("Remote SDP: ~s", [nksip_sdp:unparse(RemoteSDP)]),
     ok;
 
 sip_session_update({update, LocalSDP, RemoteSDP}, Dialog, _Call) ->
     {ok, DialogId} = nksip_dialog:get_handle(Dialog),
-    lager:notice("PBX Session ~s Update", [DialogId]),
-    lager:notice("Local SDP: ~s", [nksip_sdp:unparse(LocalSDP)]),
-    lager:notice("Remote SDP: ~s", [nksip_sdp:unparse(RemoteSDP)]),
+    logger:notice("PBX Session ~s Update", [DialogId]),
+    logger:notice("Local SDP: ~s", [nksip_sdp:unparse(LocalSDP)]),
+    logger:notice("Remote SDP: ~s", [nksip_sdp:unparse(RemoteSDP)]),
     ok;
 
 sip_session_update(Status, Dialog, _Call) ->
     {ok, DialogId} = nksip_dialog:get_handle(Dialog),
-    lager:notice("PBX Session ~s Update: ~p", [DialogId, Status]),
+    logger:notice("PBX Session ~s Update: ~p", [DialogId, Status]),
     ok.
 
 

--- a/samples/nksip_tutorial/priv/app.config
+++ b/samples/nksip_tutorial/priv/app.config
@@ -5,29 +5,6 @@
     {nksip_tutorial, [
     ]},
 
-    {lager, [
-        {handlers, [
-            {lager_console_backend, notice},
-            {lager_file_backend, [
-                {file, "samples/nksip_tutorial/log/error.log"}, 
-                {level, error}
-            ]},
-            {lager_file_backend, [
-                {file, "samples/nksip_tutorial/log/console.log"}, 
-                {level, info}
-            ]}
-        ]},
-        {crash_log, "samples/nksip_tutorial/log/crash.log"},
-        {colored, true},
-        {colors, [
-            {debug,     "\e[0;38m" },
-            {info,      "\e[0;32m" },
-            {notice,    "\e[1;36m" },
-            {warning,   "\e[1;33m" },
-            {error,     "\e[1;31m" }
-        ]}
-    ]},
-
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/samples/nksip_tutorial/priv/vm.args
+++ b/samples/nksip_tutorial/priv/vm.args
@@ -3,7 +3,6 @@
 -pa deps/goldrush/ebin 
 -pa deps/gun/ebin 
 -pa deps/jsx/ebin
--pa deps/lager/ebin 
 -pa deps/nkdocker/ebin
 -pa deps/nklib/ebin
 -pa deps/nkpacket/ebin

--- a/src/nksip.app.src
+++ b/src/nksip.app.src
@@ -10,7 +10,6 @@
         crypto,
         sasl,
         ssl,
-        lager,
         nkpacket,
         nkservice
     ]},

--- a/src/nksip_app.erl
+++ b/src/nksip_app.erl
@@ -90,10 +90,10 @@ start(_Type, _Args) ->
             {ok, Pid} = nksip_sup:start_link(),
             put(current_cseq, nksip_util:initial_cseq()-?MINUS_CSEQ),
             {ok, Vsn} = application:get_key(nksip, vsn),
-            lager:info("NkSIP v~s has started", [Vsn]),
+            logger:info("NkSIP v~s has started", [Vsn]),
             {ok, Pid};
         {error, Error} ->
-            lager:error("Error parsing config: ~p", [Error]),
+            logger:error("Error parsing config: ~p", [Error]),
             error(Error)
     end.
 

--- a/src/nksip_call_event.erl
+++ b/src/nksip_call_event.erl
@@ -43,7 +43,7 @@
 uac_pre_request(#sipmsg{class={req, 'NOTIFY'}}=Req, Dialog, _Call) ->
     case nksip_subscription_lib:find(Req, Dialog) of
         not_found ->  
-            % lager:warning("PRE REQ: ~p, ~p", 
+            % logger:warning("PRE REQ: ~p, ~p", 
             %         [nksip_subscription_lib:make_id(Req), Dialog#dialog.subscriptions]),
             {error, no_transaction};
         #subscription{class=uas} -> 

--- a/src/nksip_call_proxy.erl
+++ b/src/nksip_call_proxy.erl
@@ -47,7 +47,7 @@ route(UriList, ProxyOpts, UAS, Call) ->
             [[]] -> throw({reply, temporarily_unavailable});
             UriSet0 -> UriSet0
         end,
-        % lager:warning("URISET: ~p", [UriList]),
+        % logger:warning("URISET: ~p", [UriList]),
         #trans{method=Method} = UAS,
         case SrvId:nks_sip_route(UriSet, ProxyOpts, UAS, Call) of
             {continue, [UriSet1, ProxyOpts1, UAS1, Call1]} ->

--- a/src/nksip_call_srv.erl
+++ b/src/nksip_call_srv.erl
@@ -118,7 +118,7 @@ handle_call(get_data, _From, Call) ->
     {reply, {Trans, Forks, Dialogs}, Call};
  
 handle_call(Msg, _From, Call) ->
-    lager:error("Module ~p received unexpected sync event: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected sync event: ~p", [?MODULE, Msg]),
     {noreply, Call}.
 
 
@@ -137,7 +137,7 @@ handle_cast(stop, Call) ->
     {stop, normal, Call};
 
 handle_cast(Msg, Call) ->
-    lager:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
     {noreply, Call}.
 
 
@@ -157,18 +157,18 @@ handle_info({timeout, Ref, Type}, Call) ->
 % handle_info({'DOWN', _Ref, process, Pid, _Reason}=Info, #call{srv_id=SrvId}=Call) ->
 %     case whereis(SrvId) of
 %         undefined ->
-%             lager:warning("Srv ~p down1", [SrvId]),
+%             logger:warning("Srv ~p down1", [SrvId]),
 %             {stop, normal, Call};
 %         Pid ->
-%             lager:warning("Srv ~p down2", [SrvId]),
+%             logger:warning("Srv ~p down2", [SrvId]),
 %             {stop, normal, Call};
 %         _ ->
-%             lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+%             logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
 %             next(Call)
 %     end;
 
 handle_info(Info, Call) ->
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
     {noreply, Call}.
 
 

--- a/src/nksip_call_uas_process.erl
+++ b/src/nksip_call_uas_process.erl
@@ -134,7 +134,7 @@ check_missing_dialog(Method, _Req, UAS, #call{srv_id=SrvId}=Call) ->
     nksip_call:call().
 
 dialog(Method, Req, UAS, Call) ->
-    % lager:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
+    % logger:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
     #sipmsg{to={_, ToTag}} = Req,
     #trans{id=Id, opts=Opts, stateless=Stateless} = UAS,
     case Stateless orelse ToTag == <<>> of
@@ -227,7 +227,7 @@ call_user_sip_method(#trans{method=Method, request=Req}=UAS, #call{srv_id=SrvId}
 %     nksip_call:call().
 
 % dialog(Method, Req, UAS, Call) ->
-%     % lager:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
+%     % logger:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
 %     #sipmsg{to={_, ToTag}} = Req,
 %     #trans{id=Id, opts=Opts, stateless=Stateless} = UAS,
 %     #call{srv_id=SrvId} = Call,

--- a/src/nksip_callbacks.erl
+++ b/src/nksip_callbacks.erl
@@ -99,7 +99,7 @@ plugin_listen(Data, #{id:=Id, config_nksip:=Config}) ->
 
 plugin_start(Config, #{name:=Name}) ->
 	ok = nksip_app:start(),
-    lager:info("Plugin nksip started for service ~s", [Name]),
+    logger:info("Plugin nksip started for service ~s", [Name]),
     {ok, Config}.
 
 
@@ -107,7 +107,7 @@ plugin_start(Config, #{name:=Name}) ->
     {ok, nkservice:service()} | {stop, term()}.
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin nksip stopped for service ~s", [Name]),
+    logger:info("Plugin nksip stopped for service ~s", [Name]),
     {ok, Config}.
 
 

--- a/src/nksip_parse.erl
+++ b/src/nksip_parse.erl
@@ -401,7 +401,7 @@ parse_sipmsg(SipMsg, Headers) ->
     end,
     Contacts = case nklib_parse:uris(proplists:get_all_values(<<"contact">>, Hds2)) of
         error -> 
-            lager:warning("C: ~p", [Hds2]),
+            logger:warning("C: ~p", [Hds2]),
             throw({invalid, <<"Contact">>});
         Contacts0 -> Contacts0
     end,

--- a/src/nksip_parse_sipmsg.erl
+++ b/src/nksip_parse_sipmsg.erl
@@ -49,7 +49,7 @@ parse(Bin) ->
         {ok, Class, Headers, Rest2}
     catch
         throw:{line, _Line} -> 
-            % lager:error("LINE: ~p", [_Line]),
+            % logger:error("LINE: ~p", [_Line]),
             error
     end.
 

--- a/src/nksip_parse_via.erl
+++ b/src/nksip_parse_via.erl
@@ -71,7 +71,7 @@ vias(String, Acc) ->
         {#via{}=Via, []} -> lists:reverse([Via|Acc]);
         {#via{}=Via, Rest} -> vias(Rest, [Via|Acc]);
         {error, _Type, _Line} -> 
-            % lager:debug("Error parsing via ~s: ~p (~p)", [String, _Type, _Line]),
+            % logger:debug("Error parsing via ~s: ~p (~p)", [String, _Type, _Line]),
             error
     end.
 

--- a/src/nksip_protocol.erl
+++ b/src/nksip_protocol.erl
@@ -137,7 +137,7 @@ naptr(_, _) -> invalid.
     {ok, conn_state()} | {stop, term()}.
 
 conn_init(_NkPort) ->
-    % lager:warning("CONN INIT ~p: ~p (~p)", [SrvId:name(), P, self()]),
+    % logger:warning("CONN INIT ~p: ~p (~p)", [SrvId:name(), P, self()]),
     State = #conn_state{
         rnrn_pattern = binary:compile_pattern(<<"\r\n\r\n">>)
     },
@@ -226,7 +226,7 @@ conn_handle_call(get_refresh, From, _NkPort, State) ->
 
 
 conn_handle_call(Msg, _From, _NkPort, State) ->
-    lager:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
     {ok, State}.
 
 
@@ -245,7 +245,7 @@ conn_handle_cast(stop_refresh, _NkPort, State) ->
     {ok, State1};
 
 conn_handle_cast(Msg, _NkPort, State) ->
-    lager:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
     {ok, State}.
 
 
@@ -290,7 +290,7 @@ conn_handle_info({stun, {ok, StunIp, StunPort}}, NkPort, State) ->
         true ->
             case RefreshTime of
                 undefined ->
-                    lager:warning("STUN UNDEFINED: ~p", [self()]);
+                    logger:warning("STUN UNDEFINED: ~p", [self()]);
                 _ ->
                     ok
             end,
@@ -312,7 +312,7 @@ conn_handle_info({stun, error}, _NkPort, State) ->
     {stop, stun_error, State};
 
 conn_handle_info(Msg, _NkPort, State) ->
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Msg]),
     {ok, State}.
 
 

--- a/src/nksip_router.erl
+++ b/src/nksip_router.erl
@@ -188,7 +188,7 @@ handle_call(works, _From, #state{works=Works}=State) ->
     {reply, maps:size(Works), State};
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -207,7 +207,7 @@ handle_cast({incoming, SipMsg}, State) ->
     end;
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -223,7 +223,7 @@ handle_info({sync_work_received, Ref, Pid}, #state{works=Works}=State) ->
             WorkList1 = lists:keydelete(Ref, 1, WorkList),
             maps:put(Pid, {SrvId, CallId, WorkList1}, Works);
         error ->
-            lager:warning("Receiving sync_work_received for unknown work"),
+            logger:warning("Receiving sync_work_received for unknown work"),
             Works
     end,
     {noreply, State#state{works=Works1}};
@@ -233,7 +233,7 @@ handle_info({'DOWN', _MRef, process, Pid, _Reason}, State) ->
     case maps:find(Pid, Srvs) of
         {ok, {SrvId, CallPids}} ->
             % A service is down
-            lager:info("Service ~p (~p) down at ~p. Calls: ~p", 
+            logger:info("Service ~p (~p) down at ~p. Calls: ~p", 
                           [SrvId, SrvId:name(), Name, CallPids]),
             lists:foreach(fun(CallPid) -> gen_server:cast(CallPid, stop) end, CallPids),
             State1 = State#state{services=maps:remove(Pid, Srvs)},
@@ -258,7 +258,7 @@ handle_info({'DOWN', _MRef, process, Pid, _Reason}, State) ->
     end;
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_sdp_util.erl
+++ b/src/nksip_sdp_util.erl
@@ -97,7 +97,7 @@ add_candidates([#sdp_m{attributes=Attrs}=Media|Rest], Index, Candidates, Acc) ->
                     Data = binary:split(FRest, <<" ">>, [global]),
                     [{<<"candidate">>, Data}|FAcc];
                 _ ->
-                    lager:error("L: ~p", [Line]),
+                    logger:error("L: ~p", [Line]),
                     FAcc
             end
         end,

--- a/src/plugins/nksip_100rel_callbacks.erl
+++ b/src/plugins/nksip_100rel_callbacks.erl
@@ -52,12 +52,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Allow1 = maps:get(sip_allow, Config, []),
     Allow2 = Allow1 -- [<<"PRACK">>],
     Supported1 = maps:get(sip_supported, Config, []),

--- a/src/plugins/nksip_debug_callbacks.erl
+++ b/src/plugins/nksip_debug_callbacks.erl
@@ -62,12 +62,12 @@ plugin_start(Config, #{name:=Name}) ->
         _ ->
             ok
     end,
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_debug_srv.erl
+++ b/src/plugins/nksip_debug_srv.erl
@@ -53,7 +53,7 @@ init([]) ->
     {noreply, #state{}}.
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -62,7 +62,7 @@ handle_call(Msg, _From, State) ->
     {noreply, #state{}}.
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -71,7 +71,7 @@ handle_cast(Msg, State) ->
     {noreply, #state{}}.
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/plugins/nksip_event_compositor_callbacks.erl
+++ b/src/plugins/nksip_event_compositor_callbacks.erl
@@ -55,12 +55,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Allow1 = maps:get(sip_allow, Config, []),
     Allow2 = Allow1 -- [<<"PUBLISH">>],
     {ok, Config#{sip_allow=>Allow2}}.

--- a/src/plugins/nksip_gruu_callbacks.erl
+++ b/src/plugins/nksip_gruu_callbacks.erl
@@ -47,12 +47,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Supported1 = maps:get(sip_supported, Config, []),
     Supported2 = Supported1 -- [<<"gruu">>],
     {ok, Config#{sip_supported=>Supported2}}.

--- a/src/plugins/nksip_outbound_callbacks.erl
+++ b/src/plugins/nksip_outbound_callbacks.erl
@@ -48,12 +48,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Supported1 = maps:get(sip_supported, Config, []),
     Supported2 = Supported1 -- [<<"outbound">>],
     {ok, Config#{sip_supported=>Supported2}}.

--- a/src/plugins/nksip_refer_callbacks.erl
+++ b/src/plugins/nksip_refer_callbacks.erl
@@ -40,12 +40,12 @@ plugin_deps() ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_registrar_callbacks.erl
+++ b/src/plugins/nksip_registrar_callbacks.erl
@@ -65,13 +65,13 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{id:=SrvId, name:=Name}) ->
     nksip_registrar:clear(SrvId),
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Allow1 = maps:get(sip_allow, Config, []),
     Allow2 = Allow1 -- [<<"REGISTER">>],
     {ok, Config#{sip_allow=>Allow2}}.

--- a/src/plugins/nksip_stats_callbacks.erl
+++ b/src/plugins/nksip_stats_callbacks.erl
@@ -52,12 +52,12 @@ plugin_start(Config, #{name:=Name}) ->
         _ ->
             ok
     end,
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_stats_srv.erl
+++ b/src/plugins/nksip_stats_srv.erl
@@ -69,7 +69,7 @@ handle_call(get_uas_avg, _From, #state{last_uas=LastUas}=State) ->
     {reply, LastUas, State, timeout(State)};
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
     {noreply, State, timeout(State)}.
 
 
@@ -82,7 +82,7 @@ handle_cast({response_time, Time}, #state{avg_uas_values=Values}=State) ->
     {noreply, State1, timeout(State1)};
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    logger:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
     {noreply, State, timeout(State)}.
 
 
@@ -97,7 +97,7 @@ handle_info(timeout, #state{avg_uas_values=Values, period=Period}=State) ->
     {noreply, State1, 1000*Period};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    logger:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
     {noreply, State, timeout(State)}.
 
 

--- a/src/plugins/nksip_timers_callbacks.erl
+++ b/src/plugins/nksip_timers_callbacks.erl
@@ -57,12 +57,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     Supported1 = maps:get(sip_supported, Config, []),
     Supported2 = Supported1 -- [<<"timer">>],
     {ok, Config#{sip_supported=>Supported2}}.

--- a/src/plugins/nksip_trace_callbacks.erl
+++ b/src/plugins/nksip_trace_callbacks.erl
@@ -54,13 +54,13 @@ plugin_config(Config, #{id:=Id}) ->
 
 plugin_start(Config, #{id:=Id, name:=Name, config_nksip_trace:={File, _}}) ->
 	ok = nksip_trace:open_file(Id, File),
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
 	{ok, Config}.
 
 
 plugin_stop(Config, #{id:=Id, name:=Name}) ->
     catch nksip_trace:close_file(Id),
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_uac_auto_auth_callbacks.erl
+++ b/src/plugins/nksip_uac_auto_auth_callbacks.erl
@@ -50,17 +50,17 @@ plugin_syntax() ->
 plugin_config(Config, #{name:=Name}) ->
     Tries = maps:get(sip_uac_auto_auth_max_tries, Config, 5),
     Pass = maps:get(sip_pass, Config, []),
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config, nksip_uac_auto_auth:make_config(Tries, Pass)}.
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_uac_auto_outbound_callbacks.erl
+++ b/src/plugins/nksip_uac_auto_outbound_callbacks.erl
@@ -67,13 +67,13 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{id:=Id, name:=Name}) ->
     gen_server:cast(Id, nksip_uac_auto_outbound_terminate),
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/src/plugins/nksip_uac_auto_register_callbacks.erl
+++ b/src/plugins/nksip_uac_auto_register_callbacks.erl
@@ -59,12 +59,12 @@ plugin_config(Config, _Service) ->
 
 
 plugin_start(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p started (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p started (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 
 plugin_stop(Config, #{name:=Name}) ->
-    lager:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
+    logger:info("Plugin ~p stopped (~s)", [?MODULE, Name]),
     {ok, Config}.
 
 

--- a/test/app.config
+++ b/test/app.config
@@ -1,11 +1,6 @@
 [
     {nksip, [
     ]},
-    {lager, [
-        {handlers, [{lager_console_backend, warning}]},
-        {error_logger_redirect, false},
-        {colored, true}
-    ]},
     {sasl, [
         {sasl_error_logger, false}
     ]}

--- a/test/auth_test.erl
+++ b/test/auth_test.erl
@@ -296,7 +296,7 @@ sip_authorize(Auth, Req, _Call) ->
     IsRegister = lists:member(register, Auth),
     if
         App==server1; App==server2 ->
-            % lager:warning("AUTH AT ~p: ~p", [App, Auth]),
+            % logger:warning("AUTH AT ~p: ~p", [App, Auth]),
             case IsDialog orelse IsRegister of
                 true ->
                     ok;

--- a/test/basic2_test.erl
+++ b/test/basic2_test.erl
@@ -225,7 +225,7 @@ sip_route(Scheme, User, Domain, Req, _Call) ->
                 true when Domain =:= <<"nksip">> ->
                     case nksip_registrar:find(server1, Scheme, User, Domain) of
                         [] -> 
-                            % lager:notice("E: ~p, ~p, ~p", [Scheme, User, Domain]),
+                            % logger:notice("E: ~p, ~p, ~p", [Scheme, User, Domain]),
                             {reply, temporarily_unavailable};
                         UriList ->
                          {proxy, UriList, Opts}
@@ -246,7 +246,7 @@ sip_invite(Req, _Call) ->
     case nksip_sipmsg:header(<<"x-nk-op">>, Req) of
         [<<"wait">>] ->
             {ok, ReqId} = nksip_request:get_handle(Req),
-            lager:error("Next error about a looped_process is expected"),
+            logger:error("Next error about a looped_process is expected"),
             {error, looped_process} = nksip_request:reply(ringing, ReqId),
             spawn(
                 fun() ->

--- a/test/event_test.erl
+++ b/test/event_test.erl
@@ -267,7 +267,7 @@ dialog() ->
         {_, [<<"<sip:b1@127.0.0.1:5070;lr>">>,<<"<sip:b@b>">>,<<"<sip:a2@127.0.0.1;lr>">>]}
     ]} = nksip_dialog:metas([raw_local_target, raw_remote_target, raw_route_set], DialogA),
 
-    % lager:notice("DB: ~p", [DialogB]),
+    % logger:notice("DB: ~p", [DialogB]),
 
     {ok, [
         {_, <<"<sip:b2@127.0.0.1:5070>">>},

--- a/test/fork_test.erl
+++ b/test/fork_test.erl
@@ -353,7 +353,7 @@ invite2() ->
 
     All = nksip_dialog:get_all(),
 
-    % lager:notice("A")
+    % logger:notice("A")
 
 
     {ok, C2Id} = nkservice_srv:get_srv_id(client2),
@@ -474,7 +474,7 @@ multiple_200() ->
 
     [R1, R2, R3]= nksip_dialog:get_all(serverR, CallId1),
 
-    % lager:notice("R: ~p, ~p, ~p, ~p", [R1, R2, R3, Dlg_C1_1]),
+    % logger:notice("R: ~p, ~p, ~p, ~p", [R1, R2, R3, Dlg_C1_1]),
 
     Dlg_C1_1_SR = nksip_dialog_lib:change_app(Dlg_C1_1, serverR),
     true = lists:member(Dlg_C1_1_SR, [R1, R2, R3]),

--- a/test/outbound_test.erl
+++ b/test/outbound_test.erl
@@ -520,7 +520,7 @@ uac_auto() ->
     false = nksip_protocol:get_refresh(Pid3),
     false = nksip_protocol:get_refresh(Pid4),
 
-    % lager:error("Next error about process failed is expected"),
+    % logger:error("Next error about process failed is expected"),
     exit(Pid1, kill),
     timer:sleep(50),
     [{auto1, false, _},{auto2, true, _}] = 
@@ -558,7 +558,7 @@ check_time(Time, Limit) ->
         true ->
             ok;
         false ->
-            lager:warning("Time error ~p not int ~p", [Time, Limit]),
+            logger:warning("Time error ~p not int ~p", [Time, Limit]),
             error(time_error)
     end.
 

--- a/test/tests_util.erl
+++ b/test/tests_util.erl
@@ -81,7 +81,7 @@ wait(Ref, List) ->
                 true -> 
                     wait(Ref, List -- [Term]);
                 false -> 
-                    lager:warning("Timer Test Wait unexpected term: ~p", [Term]),
+                    logger:warning("Timer Test Wait unexpected term: ~p", [Term]),
                     wait(Ref, List)
                     % {error, {unexpected_term, Term, List}}
             end
@@ -96,7 +96,7 @@ log() ->
     log(?LOG_LEVEL).
 
 log(Level) -> 
-    lager:set_loglevel(lager_console_backend, Level).
+    logger:update_primary_config(#{level => Level}).
 
 
 get_ref() ->
@@ -129,10 +129,10 @@ send_ref(Msg, Req) ->
     Dialogs = nkservice:get(SrvId, dialogs, []),
     case lists:keyfind(DialogId, 1, Dialogs) of
         {DialogId, Ref, Pid}=_D -> 
-            % lager:warning("FOUND ~p, ~p", [SrvId, _D]),
+            % logger:warning("FOUND ~p, ~p", [SrvId, _D]),
             Pid ! {Ref, {SrvId:name(), Msg}};
         false ->
-            % lager:warning("NOT FOUND: ~p", [SrvId]),
+            % logger:warning("NOT FOUND: ~p", [SrvId]),
             ok
     end.
 

--- a/test/uac_test.erl
+++ b/test/uac_test.erl
@@ -69,9 +69,9 @@ uac() ->
     {error, {invalid, <<"route">>}} = nksip_uac:options(client2, SipC1, [{route, "<>"}]),
     {error, {invalid, <<"contact">>}} = nksip_uac:options(client2, SipC1, [{contact, "<>"}]),
     {error, {invalid_config, cseq_num}} = nksip_uac:options(client2, SipC1, [{cseq_num, -1}]),
-    % lager:error("Next error about 'unknown_sipapp' is expected"),
+    % logger:error("Next error about 'unknown_sipapp' is expected"),
     {error, service_not_found} = nksip_uac:options(none, SipC1, []),
-    lager:error("Next 2 errors about 'too_many_calls' are expected"),
+    logger:error("Next 2 errors about 'too_many_calls' are expected"),
     nklib_counters:incr(nksip_calls, 1000000000),
     {error, too_many_calls} = nksip_uac:options(client2, SipC1, []),
     nklib_counters:incr(nksip_calls, -1000000000),
@@ -93,7 +93,7 @@ uac() ->
     CB = {callback, Fun},
     Hds = [{add, "x-nk-op", busy}, {add, "x-nk-prov", "true"}],
 
-    lager:info("Next two infos about connection error to port 50600 are expected"),
+    logger:info("Next two infos about connection error to port 50600 are expected"),
     {error, service_unavailable} =
         nksip_uac:options(client2, "<sip:127.0.0.1:50600;transport=tcp>", []),
     
@@ -125,7 +125,7 @@ uac() ->
     {ok, 486, [{call_id, CallId4}, {handle, RespId4}]} = 
         nksip_uac:invite(client2, SipC1, [CB, get_request, {meta, [call_id, handle]}|Hds]),
 
-    % lager:notice("RESPID4: ~p", [RespId4]),
+    % logger:notice("RESPID4: ~p", [RespId4]),
 
 
     {ok, CallId4} = nksip_response:call_id(RespId4),
@@ -193,7 +193,7 @@ timeout() ->
     SipC1 = "sip:127.0.0.1:5070",
     ok = nksip:update(client2, [{sip_timer_t1, 10}, {sip_timer_c, 1}]),
 
-    lager:notice("Next notices about several timeouts are expected"),
+    logger:notice("Next notices about several timeouts are expected"),
 
     {ok, 408, [{reason_phrase, <<"Timer F Timeout">>}]} = 
         nksip_uac:options(client2, "sip:127.0.0.1:9999", [{meta,[reason_phrase]}]),

--- a/test/uas_test.erl
+++ b/test/uas_test.erl
@@ -116,7 +116,7 @@ uas() ->
     [<<"a,b,d">>] = proplists:get_all_values(<<"unsupported">>, Hds6),
 
     % Force invalid response
-    lager:warning("Next warning about a invalid sipreply is expected"),
+    logger:warning("Next warning about a invalid sipreply is expected"),
     {ok, 500,  [{reason_phrase, <<"Invalid Service Response">>}]} = 
         nksip_uac:options(client1, "sip:127.0.0.1", [
             {add, "x-nk-op", "reply-invalid"}, {meta, [reason_phrase]}]),
@@ -152,7 +152,7 @@ auto() ->
 
     ok = tests_util:wait(Ref, [{ping, ping1, true}, {reg, reg1, true}]),
 
-    lager:notice("Next notices about connection error to port 9999 are expected"),
+    logger:notice("Next notices about connection error to port 9999 are expected"),
     {ok, false} = nksip_uac_auto_register:start_ping(client1, ping2, 
                                             "<sip:127.0.0.1:9999;transport=tcp>",
                                             [{expires, 1}]),
@@ -176,7 +176,7 @@ auto() ->
     ok = nksip_uac_auto_register:stop_register(client1, reg1),
     ok = nksip:stop(server2),
     timer:sleep(500),
-    lager:notice("Next notice about connection error to port 5080 is expected"),
+    logger:notice("Next notice about connection error to port 5080 is expected"),
     {ok, false} = nksip_uac_auto_register:start_ping(client1, ping3, 
                                             "<sip:127.0.0.1:5080;transport=tcp>",
                                             [{expires, 1}]),


### PR DESCRIPTION
The goal is to replace `lager` with Erlang `logger` in order to remove the `lager` dependency from [MongooseIM](https://github.com/esl/mongooseim/), and integrate the output with the MongooseIM logs.

It is not required to maintain all functionality that was present before, but only to keep the library functional enough to be used in the `mod_jingle_sip` module in MongooseIM. The changes are verified by the corresponding [PR to MongooseIM](https://github.com/esl/MongooseIM/pull/4393).

Additionally:
- Make `rebar3 compile` work on Erlang 27.
- Remove modules using `lager` that are not needed by MongooseIM.
- Remove lager-related docs, because the `lager` options have now no effect. The log directory is [apparently used for cache](https://github.com/esl/MongooseIM/blob/master/rel/files/app.config#L100).